### PR TITLE
Mobile-friendly tweak

### DIFF
--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -3,7 +3,9 @@
     <div class='col'>
       <h2>Experience</h2>
     </div>
-    <div class='col-auto' id='legend'>
+  </div>
+  <div class='row'>
+    <div class='col-sm' id='legend'>
       <ul>
         <li><i class='fa fa-briefcase'></i> Employed</li>
         <li><i class='fa fa-handshake-o'></i> Contract</li>
@@ -57,7 +59,7 @@
             </div>
             {% if experience.role %}<h4>{{experience.role}}</h4>{% endif %}
             {{ experience.content }}
-            
+
             {% assign roles = site.roles | sort: "start" %}
             {% for role in roles reversed jek%}
               {% if role.experience == experience_id %}
@@ -70,7 +72,7 @@
             {% endfor %}
           </div>
         </div>
-      </div>  
+      </div>
     {% endfor %}
   </div>
 </div>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -6,53 +6,53 @@ span.skill {
 }
 
 div.jumbotron {
-  
+
   background: rgb(60,126,68) url('background.jpg');
   background-size: cover;
-  
+
   div#intro {
     background: rgba(255,255,255,0.85);
     padding: 1em;
   }
-  
+
   img#headshot {
     max-width: 25vw;
   }
-  
+
 }
 
 div.contactcard {
-  
+
   margin-bottom: 1em;
   margin-right: 1em;
-  
+
   i.contacticon {
     color: white;
   }
-  
+
 }
 
 div.experience {
-  
+
   div.experience-location {
     padding-bottom: 20px;
-    
+
     > div {
       display: inline;
       padding-right: 30px;
     }
-    
+
     address {
       display: inline;
     }
   }
-  
+
 }
 
 #legend {
-  
+
   float: right;
-  
+
   li {
     list-style-type: none;
     display: inline-block;


### PR DESCRIPTION
The icons at the top of the experience section ('employed', 'contract', 'self-employed' etc.) were not stacking on mobile, leading to a row that extended the width of the page and made it less mobile-friendly.

Undoubtedly there are other ways to fix this, but I created a new row for these icons and changed the class to 'col-sm' so that the icons stack when the page loads on a mobile screen.